### PR TITLE
 hotfix: Ajuste de credenciales para ambiente de producción, solo se puede ingresar al workspace de docencia

### DIFF
--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -9,8 +9,8 @@ export const environment = {
   NUXEO: {
     PATH: 'https://documental.portaloas.udistrital.edu.co/nuxeo/',
     CREDENTIALS: {
-      USERNAME: 'desarrollooas',
-      PASS: 'desarrollooas2019',
+      USERNAME: 'produccion_app',
+      PASS: 'Pr0ducc10n2021',
     },
   },
   CONFIGURACION_SERVICE: 'https://autenticacion.portaloas.udistrital.edu.co/apioas/configuracion_crud_api/v1/',


### PR DESCRIPTION
 hotfix: Ajuste de credenciales para ambiente de producción, solo se puede ingresar al workspace de docencia